### PR TITLE
Implement default password methods for ([u8] <-> String) conversion.

### DIFF
--- a/src/credential.rs
+++ b/src/credential.rs
@@ -18,7 +18,9 @@ pub trait CredentialApi {
     /// Set the credential's password (a string).
     ///
     /// This will persist the password in the underlying store.
-    fn set_password(&self, password: &str) -> Result<()>;
+    fn set_password(&self, password: &str) -> Result<()> {
+        self.set_secret(password.as_bytes())
+    }
 
     /// Set the credential's secret (a byte array).
     ///
@@ -29,7 +31,10 @@ pub trait CredentialApi {
     ///
     /// This has no effect on the underlying store. If there is no credential
     /// for this entry, a [NoEntry](crate::Error::NoEntry) error is returned.
-    fn get_password(&self) -> Result<String>;
+    fn get_password(&self) -> Result<String> {
+        let secret = self.get_secret()?;
+        super::error::decode_password(secret)
+    }
 
     /// Retrieve a secret (a byte array) from the credential.
     ///


### PR DESCRIPTION
Just so downstream `CredentialApi` users can skip re-implementing these if they already implement `set_secret` and `get_secret`. 

They can always override and provide an implementation if these default methods don't work for some reason.