### PR TITLE
Replace `OnceLock` with `LazyLock`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -253,14 +253,14 @@ pub fn default_credential_builder() -> Box<CredentialBuilder> {
 }
 
 fn build_default_credential(target: Option<&str>, service: &str, user: &str) -> Result<Entry> {
-    static DEFAULT: std::sync::OnceLock<Box<CredentialBuilder>> = std::sync::OnceLock::new();
+    static DEFAULT: std::sync::LazyLock<Box<CredentialBuilder>> = std::sync::LazyLock::new(default_credential_builder);
     let guard = DEFAULT_BUILDER
         .read()
         .expect("Poisoned RwLock in keyring-rs: please report a bug!");
     let builder = guard
         .inner
         .as_ref()
-        .unwrap_or_else(|| DEFAULT.get_or_init(|| default_credential_builder()));
+        .unwrap_or_else(|| &DEFAULT);
     let credential = builder.build(target, service, user)?;
     Ok(Entry { inner: credential })
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -253,14 +253,12 @@ pub fn default_credential_builder() -> Box<CredentialBuilder> {
 }
 
 fn build_default_credential(target: Option<&str>, service: &str, user: &str) -> Result<Entry> {
-    static DEFAULT: std::sync::LazyLock<Box<CredentialBuilder>> = std::sync::LazyLock::new(default_credential_builder);
+    static DEFAULT: std::sync::LazyLock<Box<CredentialBuilder>> =
+        std::sync::LazyLock::new(default_credential_builder);
     let guard = DEFAULT_BUILDER
         .read()
         .expect("Poisoned RwLock in keyring-rs: please report a bug!");
-    let builder = guard
-        .inner
-        .as_ref()
-        .unwrap_or_else(|| &DEFAULT);
+    let builder = guard.inner.as_ref().unwrap_or_else(|| &DEFAULT);
     let credential = builder.build(target, service, user)?;
     Ok(Entry { inner: credential })
 }


### PR DESCRIPTION
[`LazyLock`](https://doc.rust-lang.org/std/sync/struct.LazyLock.html) is simpler than [`OnceLock`](https://doc.rust-lang.org/std/sync/struct.OnceLock.html) and the docs suggest its use over OnceLock in simple cases where different initializers based on the caller are not required:

> In many simple cases, you can use [LazyLock<T, F>](https://doc.rust-lang.org/std/sync/struct.LazyLock.html) instead to get the benefits of this type with less effort: LazyLock<T, F> “looks like” &T because it initializes with F on deref! Where OnceLock shines is when LazyLock is too simple to support a given case, as LazyLock doesn’t allow additional inputs to its function after you call [LazyLock::new(|| ...)](https://doc.rust-lang.org/std/sync/struct.LazyLock.html#method.new).

OnceCell was used in #160 (and therefore #179) as it became stable in v1.70 whilst LazyLock became stable in v1.80. With the MSRV bump of keyring v4 to v1.85, this is no longer a consideration.