### PR TITLE
windows: use static value for 'comment' attribute

### DIFF
--- a/src/windows.rs
+++ b/src/windows.rs
@@ -362,7 +362,7 @@ impl WinCredential {
                 username: user.to_string(),
                 target_name: target.to_string(),
                 target_alias: String::new(),
-                comment: format!("{user}@{service}:{target} (keyring v{VERSION})"),
+                comment: format!("keyring v{VERSION}"),
             }
         } else {
             Self {
@@ -377,7 +377,7 @@ impl WinCredential {
                 username: user.to_string(),
                 target_name: format!("{user}.{service}"),
                 target_alias: String::new(),
-                comment: format!("{user}@{service}:{user}.{service} (keyring v{VERSION})"),
+                comment: format!("keyring v{VERSION}"),
             }
         };
         credential.validate_attributes(None, None)?;


### PR DESCRIPTION
windows: use static value for 'comment' attribute

Some Windows environments have a severely restricted 256 characters
allowed for a 'comment'. When the 'user' and 'service' attributes are
lengthy (e.g., client IDs and URLs), this information can exceed the
limit -- particularly in the 'target == None' case (where both 'user'
and 'service' are duplicated).

To add to the trouble, the call to `credential.validate_attributes()`
before this function returns prevents a consumer from updating this
comment to be within the length limit.

Switch to a static string for this comment that is within any
reasonable length limit. If a consumer would like to add their own
more verbose comment, they can do so with `Entry::update_attributes()`
after the entry is created.

Note: a pass-through optional parameter for the comment value was
considered, but there's not really a good, obvious answer for a clean
API on Entry with such an approach. The 'comment' attribute also
appears to be Windows-specific. This approach should not have any
impact on consumers and certainly does not have an impact on the API.

An alternate-alternate approach may be possible with just removing the
call to `credential.validate_attributes()`, but I don't have the
expertise to understand what the effects of this would be.

---

Fixes #264.